### PR TITLE
fix NaN handling

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -291,11 +291,11 @@ func (s *encodeState) encodeFloat64(v float64) error {
 			s.writeByte(byte(sign<<7 | 0x7c))
 			s.writeByte(0x00)
 			return nil
-		} else if frac&0x8000000000000 != 0 {
-			// qNaN in float16
+		} else if frac != 0 {
+			// NaN in float16
+			// we don't support NaN payloads or signaling NaNs.
 			s.writeByte(0xf9) // half-precision float (two-byte IEEE 754)
-			f16 := uint16(sign<<15 | 0x7c00 | frac>>42)
-			s.writeUint16(f16)
+			s.writeUint16(0x7e00)
 			return nil
 		}
 	}

--- a/float_test.go
+++ b/float_test.go
@@ -64,9 +64,6 @@ func TestFloat(t *testing.T) {
 func TestFloat_Gen(t *testing.T) {
 	for _, tt := range f64ToBytesTests {
 		input := math.Float64frombits(tt.f64)
-		if math.IsNaN(input) {
-			continue
-		}
 		got, err := Marshal(input)
 		if err != nil {
 			t.Errorf("Marshal() error = %v", err)

--- a/float_test.go
+++ b/float_test.go
@@ -69,9 +69,15 @@ func TestFloat_Gen(t *testing.T) {
 			t.Errorf("Marshal() error = %v", err)
 			continue
 		}
+		want := tt.bytes
+		if math.IsNaN(input) {
+			// support NaN payloads or signaling NaNs.
+			// NaN is always encoded as 0x7e00
+			want = []byte{0x7e, 0x00}
+		}
 		got = got[1:] // skip major type
-		if !bytes.Equal(got, tt.bytes) {
-			t.Errorf("EncodeFloat64(%x) = %x, want %x", input, got, tt.bytes)
+		if !bytes.Equal(got, want) {
+			t.Errorf("EncodeFloat64(%x) = %x, want %x", input, got, want)
 		}
 	}
 }


### PR DESCRIPTION
RFC 8949 Section 4.2.2:

> If NaN is an allowed value, and there is no intent to support NaN payloads or signaling NaNs, the protocol needs to pick a single representation, typically 0xf97e00. If that simple choice is not possible, specific attention will be needed for NaN handling.