### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "stable"
+          - "1.23"
+          - "1.22"
           - "1.21"
         arch:
           - amd64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Expanded testing coverage by adding support for additional versions of the Go programming language (stable, 1.23, and 1.22) in the CI workflow.
    - Improved reliability of the project through thorough validation across a broader set of Go environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->